### PR TITLE
Iter1

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,51 @@
+name: golangci-lint
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v5
+        with:
+          # Require: The version of golangci-lint to use.
+          # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
+          # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
+          version: v1.57
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          #
+          # Note: By default, the `.golangci.yml` file should be at the root of the repository.
+          # The location of the configuration file can be changed by using `--config=`
+          # args: --timeout=30m --config=/my/path/.golangci.yml --issues-exit-code=0
+
+          # Optional: For pull request only, show only new issues. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true, then all caching functionality will be completely disabled,
+          #           takes precedence over all other caching options.
+          # skip-cache: true
+
+          # Optional: if set to true, caches will not be saved, but they may still be restored,
+          #           subject to other options
+          # skip-save-cache: true
+
+          # Optional: The mode to install golangci-lint. It can be 'binary' or 'goinstall'.
+          # install-mode: "goinstall"

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -58,6 +58,9 @@ func main() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+	// Print the Content-Type header
+	fmt.Println("Content-Type:", response.Header.Get("Content-Type"))
+
 	// Print the response body
 	fmt.Println(string(body))
 }

--- a/cmd/shortener/main.go
+++ b/cmd/shortener/main.go
@@ -1,3 +1,12 @@
 package main
 
-func main() {}
+import (
+	"net/http"
+
+	"github.com/gennadis/shorturl/internal/app"
+)
+
+func main() {
+	http.HandleFunc("/", app.Mux)
+	http.ListenAndServe(":8080", nil)
+}

--- a/cmd/shortener/main.go
+++ b/cmd/shortener/main.go
@@ -7,7 +7,8 @@ import (
 )
 
 func main() {
-	shortener := app.App{}
+	storage := make(map[string]string)
+	shortener := app.App{Storage: storage}
 	if err := shortener.Run(); err != nil {
 		log.Println(err)
 	}

--- a/cmd/shortener/main.go
+++ b/cmd/shortener/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
-	"net/http"
+	"log"
 
 	"github.com/gennadis/shorturl/internal/app"
 )
 
 func main() {
-	http.HandleFunc("/", app.Mux)
-	http.ListenAndServe(":8080", nil)
+	shortener := app.App{}
+	if err := shortener.Run(); err != nil {
+		log.Println(err)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/gennadis/shorturl
 
-go 1.22.2
+go 1.21.9

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,0 +1,17 @@
+package app
+
+import (
+	"log"
+	"net/http"
+)
+
+func Mux(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		log.Println("GET method requested", r.RemoteAddr)
+	case http.MethodPost:
+		log.Println("POST method requested", r.RemoteAddr)
+	default:
+		log.Println("Unknown method requested", r.RemoteAddr)
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -11,7 +11,9 @@ import (
 
 const slugLen = 6
 
-type App struct{}
+type App struct {
+	Storage map[string]string
+}
 
 func (a *App) Run() error {
 	http.HandleFunc("/", a.Mux)
@@ -41,6 +43,9 @@ func (a *App) shorten(w http.ResponseWriter, r *http.Request) {
 	_slug := slug.Generate(slugLen)
 	shortURL := fmt.Sprintf("http://127.0.0.1:8080/%s", _slug)
 	log.Printf("shortened url: %s", shortURL)
+
+	a.Storage[_slug] = string(url)
+	log.Println(a.Storage)
 
 	w.WriteHeader(http.StatusCreated)
 	w.Header().Set("Content-Type", "text/plain")

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -14,19 +14,18 @@ func (a *App) Run() error {
 }
 
 func (a *App) Mux(w http.ResponseWriter, r *http.Request) {
+	log.Printf("%s method requested by %s", r.Method, r.RemoteAddr)
 	switch r.Method {
 	case http.MethodGet:
 		a.expand(w, r)
 	case http.MethodPost:
 		a.shorten(w, r)
 	default:
-		log.Println("Unknown method requested", r.RemoteAddr)
+		w.WriteHeader(http.StatusBadRequest)
 	}
 }
 
 func (a *App) shorten(w http.ResponseWriter, r *http.Request) {
-	log.Println("GET method requested", r.RemoteAddr)
-
 	defer r.Body.Close()
 	url, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -40,7 +39,6 @@ func (a *App) shorten(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) expand(w http.ResponseWriter, r *http.Request) {
-	log.Println("POST method requested", w, r.RemoteAddr)
 }
 
 func createHash(url string) string {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -34,6 +34,8 @@ func (a *App) shorten(w http.ResponseWriter, r *http.Request) {
 	}
 
 	hash := createHash(string(url))
+	w.WriteHeader(http.StatusCreated)
+	w.Header().Add("Content-Type", "text/plain")
 	w.Write([]byte(hash))
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,10 +1,15 @@
 package app
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"net/http"
+
+	"github.com/gennadis/shorturl/internal/slug"
 )
+
+const slugLen = 6
 
 type App struct{}
 
@@ -29,19 +34,22 @@ func (a *App) shorten(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	url, err := io.ReadAll(r.Body)
 	if err != nil {
-		log.Fatalln("error")
+		http.Error(w, "failed to read request body", http.StatusInternalServerError)
 	}
+	log.Printf("original url: %s", url)
 
-	hash := createHash(string(url))
+	_slug := slug.Generate(slugLen)
+	shortURL := fmt.Sprintf("http://127.0.0.1:8080/%s", _slug)
+	log.Printf("shortened url: %s", shortURL)
+
 	w.WriteHeader(http.StatusCreated)
-	w.Header().Add("Content-Type", "text/plain")
-	w.Write([]byte(hash))
+	w.Header().Set("Content-Type", "text/plain")
+	_, err = w.Write([]byte(shortURL))
+	if err != nil {
+		log.Println("error writing response:", err)
+	}
 }
 
 func (a *App) expand(w http.ResponseWriter, r *http.Request) {
-}
-
-func createHash(url string) string {
-	log.Printf("original url %s", url)
-	return "shortUrl"
+	// To be implemented
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,17 +1,47 @@
 package app
 
 import (
+	"io"
 	"log"
 	"net/http"
 )
 
-func Mux(w http.ResponseWriter, r *http.Request) {
+type App struct{}
+
+func (a *App) Run() error {
+	http.HandleFunc("/", a.Mux)
+	return http.ListenAndServe(":8080", nil)
+}
+
+func (a *App) Mux(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
-		log.Println("GET method requested", r.RemoteAddr)
+		a.expand(w, r)
 	case http.MethodPost:
-		log.Println("POST method requested", r.RemoteAddr)
+		a.shorten(w, r)
 	default:
 		log.Println("Unknown method requested", r.RemoteAddr)
 	}
+}
+
+func (a *App) shorten(w http.ResponseWriter, r *http.Request) {
+	log.Println("GET method requested", r.RemoteAddr)
+
+	defer r.Body.Close()
+	url, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Fatalln("error")
+	}
+
+	hash := createHash(string(url))
+	w.Write([]byte(hash))
+}
+
+func (a *App) expand(w http.ResponseWriter, r *http.Request) {
+	log.Println("POST method requested", w, r.RemoteAddr)
+}
+
+func createHash(url string) string {
+	log.Printf("original url %s", url)
+	return "shortUrl"
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -21,7 +21,7 @@ func (a *App) Run() error {
 }
 
 func (a *App) Mux(w http.ResponseWriter, r *http.Request) {
-	log.Printf("%s method requested by %s", r.Method, r.RemoteAddr)
+	log.Printf("%s %s method requested by %s", r.Method, r.RequestURI, r.RemoteAddr)
 	switch r.Method {
 	case http.MethodGet:
 		a.expand(w, r)
@@ -58,11 +58,14 @@ func (a *App) shorten(w http.ResponseWriter, r *http.Request) {
 
 func (a *App) expand(w http.ResponseWriter, r *http.Request) {
 	slug := r.URL.Path[1:]
+	log.Printf("originalURL for slug %s requested", slug)
 	originalURL, ok := a.Storage[slug]
 	if !ok {
+		log.Printf("slug %s not found", slug)
 		http.Error(w, "slug not found", http.StatusNotFound)
 		return
 	}
+	log.Printf("originalURL for slug %s found: %s", a.Storage, originalURL)
 	w.Header().Set("Location", originalURL)
 	w.WriteHeader(http.StatusTemporaryRedirect)
 }

--- a/internal/slug/slug.go
+++ b/internal/slug/slug.go
@@ -1,0 +1,15 @@
+package slug
+
+import (
+	"math/rand"
+)
+
+const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func Generate(length int) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
+}


### PR DESCRIPTION
- Added functionality to create a server accessible at http://localhost:8080/.
- Implemented two endpoints: `POST /` and `GET /{id}`
- Endpoint `POST /` accepts a URL string in the request body for shortening and returns a response with status code `201` and the shortened URL as a text string in the body
- Endpoint `GET /{id}` accepts the identifier of the shortened URL as a URL parameter and returns a response with status code `307` and the original URL in the HTTP `Location` header
- Implemented handling for invalid requests, returning a response with status code 400